### PR TITLE
Code-Inside URL auf .eu geändert

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
                                         juristischen Belangen der Software Entwicklung für Kundenprojekte jeder Größenordnung und Branche. Neben ihrer beratenden Tätigkeit bietet Antje
                                         Trainings und Seminare rund um das Thema IT-Recht und ist gern gesehener Speaker auf Fachveranstaltungen der Branche, wie der MDC oder  den verschiedenen
                                         User Groups. Ihr besonderes Interesse gilt dabei vor allem dem Software-Lizenzrecht. In ihrer Freizeit unterstützt sie den deutschen Entwicklerblog
-                        <a href="http://code-inside.de" target="_blank">Code-Inside</a> mit der Pflege der englischsprachigen Seite sowie mit Gastbeiträgen zu juristischen Themen.
+                        <a href="http://www.codeinside.eu" target="_blank">Code-Inside</a> mit der Pflege der englischsprachigen Seite sowie mit Gastbeiträgen zu juristischen Themen.
                                     </p>
                         <p>
                             <header>


### PR DESCRIPTION
code-inside.de ist die alte URL, die neue URL zum gemeinsamen Dashboard (auf dem auch Antje zu sehen ist), ist www.codeinside.eu.
